### PR TITLE
Fixed: missing darwin buildApexPacket and sendHIDFeatureReport bug

### DIFF
--- a/build-darwin.sh
+++ b/build-darwin.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Build script for SteelClock on macOS (Apple Silicon)
+# Can be run natively on macOS or for cross-compilation
+#
+# Usage:
+#   ./build-darwin.sh         # Full build (all widgets)
+#   ./build-darwin.sh --light # Light build (excludes heavy widgets)
+#   ./build-darwin.sh -l      # Same as --light
+
+set -e
+
+# Parse arguments
+BUILD_VARIANT="full"
+BUILD_TAGS=""
+OUTPUT_SUFFIX=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --light|-l)
+            BUILD_VARIANT="light"
+            BUILD_TAGS="-tags light"
+            OUTPUT_SUFFIX="-light"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--light|-l]"
+            exit 1
+            ;;
+    esac
+done
+
+echo "======================================"
+echo "Building SteelClock for macOS ($BUILD_VARIANT)"
+echo "======================================"
+echo ""
+
+# Determine if we're building natively on macOS
+NATIVE_BUILD=false
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    NATIVE_BUILD=true
+fi
+
+# Detect architecture
+if [ "$NATIVE_BUILD" = true ]; then
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "arm64" ]; then
+        GOARCH="arm64"
+    else
+        GOARCH="amd64"
+    fi
+else
+    # Default to arm64 for cross-compilation (Apple Silicon)
+    GOARCH="arm64"
+fi
+
+# Step 1: Cleanup old build
+echo "[1/3] Cleaning old build..."
+rm -f steelclock steelclock-light
+rm -f internal/tray/icon.ico
+echo "OK Cleanup complete"
+echo ""
+
+# Step 2: Copy tray icon
+echo "[2/3] Preparing tray icon..."
+if [ -f "winres/icon.ico" ]; then
+    mkdir -p internal/tray
+    cp winres/icon.ico internal/tray/icon.ico
+    echo "OK Copied icon.ico to internal/tray/"
+else
+    echo "!! Warning: winres/icon.ico not found"
+    echo "   Tray icon will use default"
+fi
+echo ""
+
+# Step 3: Build executable
+echo "[3/3] Compiling executable ($BUILD_VARIANT, GOARCH=$GOARCH)..."
+OUTPUT_NAME="steelclock${OUTPUT_SUFFIX}"
+GOOS=darwin GOARCH="$GOARCH" go build $BUILD_TAGS -ldflags="-s -w" -o "$OUTPUT_NAME" ./cmd/steelclock
+echo "OK Compilation successful"
+echo ""
+
+# Summary
+echo "======================================"
+echo "Build Summary ($BUILD_VARIANT)"
+echo "======================================"
+ls -lh "$OUTPUT_NAME"
+file "$OUTPUT_NAME"
+
+echo ""
+echo "OK Build complete!"
+echo ""
+echo "Usage:"
+echo "  ./$OUTPUT_NAME                    # Run"
+echo "  ./$OUTPUT_NAME -config config.json"
+echo ""
+echo "Note: macOS may require granting USB/HID access permissions."
+echo "  If the app is blocked by Gatekeeper, run:"
+echo "  xattr -d com.apple.quarantine ./$OUTPUT_NAME"
+echo ""
+echo "Logs: steelclock.log in the same directory as the executable"

--- a/internal/autostart/autostart_darwin.go
+++ b/internal/autostart/autostart_darwin.go
@@ -1,0 +1,98 @@
+//go:build darwin
+
+package autostart
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const plistFileName = "com.steelclock.app.plist"
+
+// launchAgentsDir returns ~/Library/LaunchAgents.
+func launchAgentsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents"), nil
+}
+
+// plistFilePath returns the full path to the LaunchAgent plist file.
+func plistFilePath() (string, error) {
+	dir, err := launchAgentsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, plistFileName), nil
+}
+
+func isEnabled() (bool, error) {
+	path, err := plistFilePath()
+	if err != nil {
+		return false, err
+	}
+
+	_, err = os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func enable() error {
+	exePath, exeDir, err := getAppPaths()
+	if err != nil {
+		return err
+	}
+
+	dir, err := launchAgentsDir()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	path, err := plistFilePath()
+	if err != nil {
+		return err
+	}
+
+	content := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.steelclock.app</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>%s</string>
+	</array>
+	<key>WorkingDirectory</key>
+	<string>%s</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+</dict>
+</plist>
+`, exePath, exeDir)
+
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func disable() error {
+	path, err := plistFilePath()
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil // already removed
+	}
+	return err
+}

--- a/internal/autostart/autostart_stub.go
+++ b/internal/autostart/autostart_stub.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package autostart
 

--- a/internal/coreaudio/tap_darwin.go
+++ b/internal/coreaudio/tap_darwin.go
@@ -1,0 +1,427 @@
+//go:build darwin
+
+package coreaudio
+
+/*
+#cgo LDFLAGS: -framework CoreAudio -framework AudioToolbox
+
+#include <CoreAudio/CoreAudio.h>
+#include <AudioToolbox/AudioToolbox.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdatomic.h>
+
+// Ring buffer for audio samples (lock-free single producer, single consumer)
+#define RING_SIZE 16384
+
+typedef struct {
+	float left[RING_SIZE];
+	float right[RING_SIZE];
+	_Atomic uint64_t writePos;
+	uint64_t readPos; // only accessed by Go consumer
+
+	// Peak levels updated by IOProc via atomics
+	_Atomic uint32_t peakLeft;  // float bits stored as uint32
+	_Atomic uint32_t peakRight;
+
+	AudioDeviceID aggregateID;
+	AudioDeviceIOProcID ioProcID;
+	int sampleRate;
+	int channels;
+	int running;
+} AudioTapState;
+
+// floatToUint32 / uint32ToFloat for atomic peak storage
+static inline uint32_t floatBitsToUint32(float f) {
+	uint32_t r;
+	memcpy(&r, &f, sizeof(r));
+	return r;
+}
+
+static inline float uint32BitsToFloat(uint32_t u) {
+	float r;
+	memcpy(&r, &u, sizeof(r));
+	return r;
+}
+
+// IOProc callback - called on real-time audio thread
+static OSStatus tapIOProc(
+	AudioDeviceID device,
+	const AudioTimeStamp *now,
+	const AudioBufferList *inputData,
+	const AudioTimeStamp *inputTime,
+	AudioBufferList *outputData,
+	const AudioTimeStamp *outputTime,
+	void *clientData
+) {
+	AudioTapState *state = (AudioTapState *)clientData;
+	if (!state || !inputData || inputData->mNumberBuffers == 0) return noErr;
+
+	AudioBuffer buf = inputData->mBuffers[0];
+	float *samples = (float *)buf.mData;
+	UInt32 numChannels = buf.mNumberChannels;
+	UInt32 numFrames = buf.mDataByteSize / (numChannels * sizeof(float));
+
+	float peakL = 0.0f, peakR = 0.0f;
+	uint64_t wp = atomic_load_explicit(&state->writePos, memory_order_relaxed);
+
+	for (UInt32 i = 0; i < numFrames; i++) {
+		float left = samples[i * numChannels];
+		float right = (numChannels >= 2) ? samples[i * numChannels + 1] : left;
+
+		uint64_t idx = (wp + i) % RING_SIZE;
+		state->left[idx] = left;
+		state->right[idx] = right;
+
+		float absL = left < 0 ? -left : left;
+		float absR = right < 0 ? -right : right;
+		if (absL > peakL) peakL = absL;
+		if (absR > peakR) peakR = absR;
+	}
+
+	atomic_store_explicit(&state->writePos, wp + numFrames, memory_order_release);
+	atomic_store_explicit(&state->peakLeft, floatBitsToUint32(peakL), memory_order_release);
+	atomic_store_explicit(&state->peakRight, floatBitsToUint32(peakR), memory_order_release);
+
+	// Silence output
+	for (UInt32 i = 0; i < outputData->mNumberBuffers; i++) {
+		memset(outputData->mBuffers[i].mData, 0, outputData->mBuffers[i].mDataByteSize);
+	}
+
+	return noErr;
+}
+
+// getDefaultOutputDeviceID returns the default output audio device
+static AudioDeviceID getDefaultOutputDevice(void) {
+	AudioDeviceID deviceID = kAudioObjectUnknown;
+	UInt32 size = sizeof(deviceID);
+	AudioObjectPropertyAddress addr = {
+		kAudioHardwarePropertyDefaultOutputDevice,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMain
+	};
+	AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, &deviceID);
+	return deviceID;
+}
+
+// createAudioTap creates an aggregate device tap for system audio capture
+static AudioTapState* createAudioTap(void) {
+	AudioDeviceID outputDevice = getDefaultOutputDevice();
+	if (outputDevice == kAudioObjectUnknown) return NULL;
+
+	AudioTapState *state = (AudioTapState *)calloc(1, sizeof(AudioTapState));
+	if (!state) return NULL;
+
+	// Get the UID of the default output device
+	CFStringRef outputUID = NULL;
+	UInt32 size = sizeof(outputUID);
+	AudioObjectPropertyAddress uidAddr = {
+		kAudioDevicePropertyDeviceUID,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMain
+	};
+	OSStatus err = AudioObjectGetPropertyData(outputDevice, &uidAddr, 0, NULL, &size, &outputUID);
+	if (err != noErr || !outputUID) {
+		free(state);
+		return NULL;
+	}
+
+	// Create aggregate device description with tap
+	CFMutableDictionaryRef aggDesc = CFDictionaryCreateMutable(
+		kCFAllocatorDefault, 0,
+		&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+	// Unique UID for our aggregate
+	CFStringRef aggUID = CFSTR("com.steelclock.audiotap");
+	CFDictionarySetValue(aggDesc, CFSTR(kAudioAggregateDeviceUIDKey), aggUID);
+	CFDictionarySetValue(aggDesc, CFSTR(kAudioAggregateDeviceNameKey), CFSTR("SteelClock Audio Tap"));
+
+	// Mark as private (not shown in system prefs)
+	int isPrivate = 1;
+	CFNumberRef privateVal = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &isPrivate);
+	CFDictionarySetValue(aggDesc, CFSTR(kAudioAggregateDeviceIsPrivateKey), privateVal);
+	CFRelease(privateVal);
+
+	// Create tap sub-device referencing the output device
+	CFMutableDictionaryRef tapSubDevice = CFDictionaryCreateMutable(
+		kCFAllocatorDefault, 0,
+		&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(tapSubDevice, CFSTR(kAudioSubDeviceUIDKey), outputUID);
+
+	CFMutableArrayRef tapList = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(tapList, tapSubDevice);
+	CFDictionarySetValue(aggDesc, CFSTR(kAudioAggregateDeviceTapListKey), tapList);
+
+	// Also set as sub-device list for compatibility
+	CFMutableDictionaryRef subDevice = CFDictionaryCreateMutable(
+		kCFAllocatorDefault, 0,
+		&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(subDevice, CFSTR(kAudioSubDeviceUIDKey), outputUID);
+
+	CFMutableArrayRef subDeviceList = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+	CFArrayAppendValue(subDeviceList, subDevice);
+	CFDictionarySetValue(aggDesc, CFSTR(kAudioAggregateDeviceSubDeviceListKey), subDeviceList);
+
+	// Create the aggregate device
+	AudioDeviceID aggDevice = kAudioObjectUnknown;
+	err = AudioHardwareCreateAggregateDevice(aggDesc, &aggDevice);
+
+	CFRelease(aggDesc);
+	CFRelease(tapSubDevice);
+	CFRelease(tapList);
+	CFRelease(subDevice);
+	CFRelease(subDeviceList);
+	CFRelease(outputUID);
+
+	if (err != noErr || aggDevice == kAudioObjectUnknown) {
+		free(state);
+		return NULL;
+	}
+
+	state->aggregateID = aggDevice;
+
+	// Get sample rate from the aggregate device
+	Float64 sampleRate = 0;
+	size = sizeof(sampleRate);
+	AudioObjectPropertyAddress srAddr = {
+		kAudioDevicePropertyNominalSampleRate,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMain
+	};
+	err = AudioObjectGetPropertyData(aggDevice, &srAddr, 0, NULL, &size, &sampleRate);
+	if (err == noErr && sampleRate > 0) {
+		state->sampleRate = (int)sampleRate;
+	} else {
+		state->sampleRate = 48000;
+	}
+	state->channels = 2;
+
+	// Install IOProc
+	err = AudioDeviceCreateIOProcID(aggDevice, tapIOProc, state, &state->ioProcID);
+	if (err != noErr) {
+		AudioHardwareDestroyAggregateDevice(aggDevice);
+		free(state);
+		return NULL;
+	}
+
+	// Start the device
+	err = AudioDeviceStart(aggDevice, state->ioProcID);
+	if (err != noErr) {
+		AudioDeviceDestroyIOProcID(aggDevice, state->ioProcID);
+		AudioHardwareDestroyAggregateDevice(aggDevice);
+		free(state);
+		return NULL;
+	}
+
+	state->running = 1;
+	return state;
+}
+
+// destroyAudioTap stops and cleans up the audio tap
+static void destroyAudioTap(AudioTapState *state) {
+	if (!state) return;
+
+	if (state->running) {
+		AudioDeviceStop(state->aggregateID, state->ioProcID);
+		state->running = 0;
+	}
+
+	if (state->ioProcID) {
+		AudioDeviceDestroyIOProcID(state->aggregateID, state->ioProcID);
+	}
+
+	if (state->aggregateID != kAudioObjectUnknown) {
+		AudioHardwareDestroyAggregateDevice(state->aggregateID);
+	}
+
+	free(state);
+}
+
+// readPeaks reads the current peak levels atomically
+static void readPeaks(AudioTapState *state, float *left, float *right) {
+	*left = uint32BitsToFloat(atomic_load_explicit(&state->peakLeft, memory_order_acquire));
+	*right = uint32BitsToFloat(atomic_load_explicit(&state->peakRight, memory_order_acquire));
+	// Reset peaks after reading
+	atomic_store_explicit(&state->peakLeft, 0, memory_order_release);
+	atomic_store_explicit(&state->peakRight, 0, memory_order_release);
+}
+
+// readSamples copies available samples from the ring buffer
+// Returns number of frames copied
+static uint64_t readSamples(AudioTapState *state, float *outLeft, float *outRight, uint64_t maxFrames, uint64_t *readPos) {
+	uint64_t wp = atomic_load_explicit(&state->writePos, memory_order_acquire);
+	uint64_t rp = *readPos;
+
+	uint64_t available = wp - rp;
+	if (available > RING_SIZE) {
+		// Reader fell behind, skip to recent data
+		rp = wp - RING_SIZE;
+		available = RING_SIZE;
+	}
+	if (available > maxFrames) {
+		// Skip older samples to only return most recent
+		rp = wp - maxFrames;
+		available = maxFrames;
+	}
+
+	for (uint64_t i = 0; i < available; i++) {
+		uint64_t idx = (rp + i) % RING_SIZE;
+		outLeft[i] = state->left[idx];
+		outRight[i] = state->right[idx];
+	}
+
+	*readPos = rp + available;
+	return available;
+}
+
+static int tapIsRunning(AudioTapState *state) {
+	return state ? state->running : 0;
+}
+
+static int tapGetSampleRate(AudioTapState *state) {
+	return state ? state->sampleRate : 0;
+}
+
+static int tapGetChannels(AudioTapState *state) {
+	return state ? state->channels : 0;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"unsafe"
+)
+
+const ringSize = 16384
+
+// AudioTap provides real-time system audio capture on macOS via CoreAudio aggregate device tap
+type AudioTap struct {
+	mu      sync.Mutex
+	state   *C.AudioTapState
+	readPos C.uint64_t
+}
+
+// NewAudioTap creates and starts a new audio tap
+func NewAudioTap() (*AudioTap, error) {
+	state := C.createAudioTap()
+	if state == nil {
+		return nil, fmt.Errorf("failed to create CoreAudio aggregate device tap")
+	}
+
+	log.Printf("[COREAUDIO-TAP] Audio tap started (sample rate: %d, channels: %d)",
+		int(state.sampleRate), int(state.channels))
+
+	return &AudioTap{
+		state: state,
+	}, nil
+}
+
+// GetPeakLevels returns the current peak levels (0.0-1.0) since the last call
+func (t *AudioTap) GetPeakLevels() (left, right float64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state == nil {
+		return 0, 0
+	}
+
+	var l, r C.float
+	C.readPeaks(t.state, &l, &r)
+	return float64(l), float64(r)
+}
+
+// ReadSamples returns available audio samples from the ring buffer
+func (t *AudioTap) ReadSamples() (left, right []float32, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state == nil {
+		return nil, nil, fmt.Errorf("audio tap not running")
+	}
+
+	var outLeft [ringSize]C.float
+	var outRight [ringSize]C.float
+
+	count := C.readSamples(t.state,
+		(*C.float)(unsafe.Pointer(&outLeft[0])),
+		(*C.float)(unsafe.Pointer(&outRight[0])),
+		C.uint64_t(ringSize),
+		&t.readPos)
+
+	if count == 0 {
+		return nil, nil, nil
+	}
+
+	n := int(count)
+	left = make([]float32, n)
+	right = make([]float32, n)
+	for i := 0; i < n; i++ {
+		left[i] = float32(outLeft[i])
+		right[i] = float32(outRight[i])
+	}
+
+	return left, right, nil
+}
+
+// GetRecentSamples returns the most recent N samples
+func (t *AudioTap) GetRecentSamples(count int) (left, right []float32) {
+	l, r, err := t.ReadSamples()
+	if err != nil || len(l) == 0 {
+		return nil, nil
+	}
+
+	if count >= len(l) {
+		return l, r
+	}
+
+	start := len(l) - count
+	return l[start:], r[start:]
+}
+
+// SampleRate returns the capture sample rate
+func (t *AudioTap) SampleRate() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state == nil {
+		return 0
+	}
+	return int(C.tapGetSampleRate(t.state))
+}
+
+// Channels returns the number of capture channels
+func (t *AudioTap) Channels() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state == nil {
+		return 0
+	}
+	return int(C.tapGetChannels(t.state))
+}
+
+// IsRunning returns true if the audio tap is active
+func (t *AudioTap) IsRunning() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state == nil {
+		return false
+	}
+	return C.tapIsRunning(t.state) != 0
+}
+
+// Close stops and destroys the audio tap
+func (t *AudioTap) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.state != nil {
+		C.destroyAudioTap(t.state)
+		t.state = nil
+		log.Println("[COREAUDIO-TAP] Audio tap stopped")
+	}
+}

--- a/internal/coreaudio/tap_stub.go
+++ b/internal/coreaudio/tap_stub.go
@@ -1,0 +1,36 @@
+//go:build !darwin
+
+package coreaudio
+
+import "fmt"
+
+// AudioTap is a stub for non-darwin platforms
+type AudioTap struct{}
+
+// NewAudioTap returns an error on non-darwin platforms
+func NewAudioTap() (*AudioTap, error) {
+	return nil, fmt.Errorf("CoreAudio tap is only supported on macOS")
+}
+
+// GetPeakLevels returns zero levels on unsupported platforms
+func (t *AudioTap) GetPeakLevels() (left, right float64) { return 0, 0 }
+
+// ReadSamples returns an error on unsupported platforms
+func (t *AudioTap) ReadSamples() (left, right []float32, err error) {
+	return nil, nil, fmt.Errorf("CoreAudio tap is only supported on macOS")
+}
+
+// GetRecentSamples returns nil on unsupported platforms
+func (t *AudioTap) GetRecentSamples(count int) (left, right []float32) { return nil, nil }
+
+// SampleRate returns 0 on unsupported platforms
+func (t *AudioTap) SampleRate() int { return 0 }
+
+// Channels returns 0 on unsupported platforms
+func (t *AudioTap) Channels() int { return 0 }
+
+// IsRunning returns false on unsupported platforms
+func (t *AudioTap) IsRunning() bool { return false }
+
+// Close is a no-op on unsupported platforms
+func (t *AudioTap) Close() {}

--- a/internal/dialog/dialog_darwin.go
+++ b/internal/dialog/dialog_darwin.go
@@ -1,0 +1,62 @@
+//go:build darwin
+
+// Package dialog provides native macOS dialogs via osascript.
+package dialog
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// InputBox shows a native macOS input dialog using osascript.
+func InputBox(title, prompt string, masked bool) (string, bool) {
+	safeTitle := strings.ReplaceAll(title, `"`, `\"`)
+	safePrompt := strings.ReplaceAll(prompt, `"`, `\"`)
+
+	var script string
+	if masked {
+		script = fmt.Sprintf(
+			`display dialog "%s" with title "%s" default answer "" with hidden answer`,
+			safePrompt, safeTitle,
+		)
+	} else {
+		script = fmt.Sprintf(
+			`display dialog "%s" with title "%s" default answer ""`,
+			safePrompt, safeTitle,
+		)
+	}
+
+	out, err := exec.Command("osascript", "-e", script).Output()
+	if err != nil {
+		// User cancelled or osascript failed
+		return "", false
+	}
+
+	// osascript returns "text returned:VALUE"
+	result := strings.TrimSpace(string(out))
+	prefix := "text returned:"
+	if strings.HasPrefix(result, prefix) {
+		return result[len(prefix):], true
+	}
+
+	return result, true
+}
+
+// ShowMessage displays a native macOS message dialog using osascript.
+func ShowMessage(title, message string, isError bool) {
+	safeTitle := strings.ReplaceAll(title, `"`, `\"`)
+	safeMessage := strings.ReplaceAll(message, `"`, `\"`)
+
+	var icon string
+	if isError {
+		icon = " with icon stop"
+	}
+
+	script := fmt.Sprintf(
+		`display dialog "%s" with title "%s" buttons {"OK"} default button "OK"%s`,
+		safeMessage, safeTitle, icon,
+	)
+
+	_ = exec.Command("osascript", "-e", script).Run()
+}

--- a/internal/dialog/dialog_stub.go
+++ b/internal/dialog/dialog_stub.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !darwin
 
 // Package dialog provides simple input dialogs
 package dialog

--- a/internal/driver/hid_darwin.go
+++ b/internal/driver/hid_darwin.go
@@ -196,16 +196,12 @@ static int sendHIDFeatureReport(void *devicePtr, const uint8_t *data, int length
 	IOHIDDeviceRef device = (IOHIDDeviceRef)devicePtr;
 
 	// The report ID is the first byte of the data, per convention.
-	// On macOS, IOHIDDeviceSetReport takes the report ID separately.
+	// On macOS, IOHIDDeviceSetReport takes the report ID separately from the data buffer,
+	// so we always strip data[0] as the report ID. Report ID 0 means the device has no
+	// report IDs (single-report device per HID spec).
 	uint8_t reportID = data[0];
 	const uint8_t *reportData = data + 1;
 	CFIndex reportLength = length - 1;
-
-	// If report ID is 0, send the entire buffer as the report
-	if (reportID == 0) {
-		reportData = data;
-		reportLength = length;
-	}
 
 	IOReturn result = IOHIDDeviceSetReport(device,
 		kIOHIDReportTypeFeature, reportID,

--- a/internal/driver/hid_darwin.go
+++ b/internal/driver/hid_darwin.go
@@ -1,0 +1,388 @@
+//go:build darwin
+
+package driver
+
+/*
+#cgo LDFLAGS: -framework IOKit -framework CoreFoundation
+
+#include <IOKit/hid/IOHIDManager.h>
+#include <IOKit/hid/IOHIDDevice.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Helper to get an integer property from a HID device
+static int64_t getDeviceIntProperty(IOHIDDeviceRef device, CFStringRef key) {
+	CFTypeRef ref = IOHIDDeviceGetProperty(device, key);
+	if (ref && CFGetTypeID(ref) == CFNumberGetTypeID()) {
+		int64_t value = 0;
+		CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt64Type, &value);
+		return value;
+	}
+	return -1;
+}
+
+// Helper to get a string property from a HID device
+// Caller must free the returned string.
+static char* getDeviceStringProperty(IOHIDDeviceRef device, CFStringRef key) {
+	CFTypeRef ref = IOHIDDeviceGetProperty(device, key);
+	if (ref && CFGetTypeID(ref) == CFStringGetTypeID()) {
+		CFIndex length = CFStringGetMaximumSizeForEncoding(
+			CFStringGetLength((CFStringRef)ref), kCFStringEncodingUTF8) + 1;
+		char *buf = (char *)malloc(length);
+		if (buf && CFStringGetCString((CFStringRef)ref, buf, length, kCFStringEncodingUTF8)) {
+			return buf;
+		}
+		free(buf);
+	}
+	return NULL;
+}
+
+// Enumerate HID devices matching optional VID/PID filters.
+// Returns count of devices found. Fills arrays with device info.
+// Caller must free string arrays.
+static int enumerateHID(
+	int filterVID, int filterPID,
+	int64_t *vids, int64_t *pids,
+	char **products, char **manufacturers, char **paths,
+	int maxDevices
+) {
+	IOHIDManagerRef manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+	if (!manager) return 0;
+
+	// Build matching dictionary
+	CFMutableDictionaryRef matchDict = NULL;
+	if (filterVID >= 0 || filterPID >= 0) {
+		matchDict = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+			&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+		if (filterVID >= 0) {
+			CFNumberRef vidNum = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &filterVID);
+			CFDictionarySetValue(matchDict, CFSTR(kIOHIDVendorIDKey), vidNum);
+			CFRelease(vidNum);
+		}
+		if (filterPID >= 0) {
+			CFNumberRef pidNum = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &filterPID);
+			CFDictionarySetValue(matchDict, CFSTR(kIOHIDProductIDKey), pidNum);
+			CFRelease(pidNum);
+		}
+	}
+
+	IOHIDManagerSetDeviceMatching(manager, matchDict);
+	if (matchDict) CFRelease(matchDict);
+
+	IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
+
+	CFSetRef deviceSet = IOHIDManagerCopyDevices(manager);
+	if (!deviceSet) {
+		IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
+		CFRelease(manager);
+		return 0;
+	}
+
+	CFIndex count = CFSetGetCount(deviceSet);
+	if (count > maxDevices) count = maxDevices;
+
+	const void **devices = (const void **)malloc(sizeof(void*) * count);
+	CFSetGetValues(deviceSet, devices);
+
+	int found = 0;
+	for (CFIndex i = 0; i < count && found < maxDevices; i++) {
+		IOHIDDeviceRef device = (IOHIDDeviceRef)devices[i];
+
+		vids[found] = getDeviceIntProperty(device, CFSTR(kIOHIDVendorIDKey));
+		pids[found] = getDeviceIntProperty(device, CFSTR(kIOHIDProductIDKey));
+		products[found] = getDeviceStringProperty(device, CFSTR(kIOHIDProductKey));
+		manufacturers[found] = getDeviceStringProperty(device, CFSTR(kIOHIDManufacturerKey));
+
+		// Build a unique path from the transport + location
+		char pathBuf[256];
+		char *transport = getDeviceStringProperty(device, CFSTR(kIOHIDTransportKey));
+		int64_t locationID = getDeviceIntProperty(device, CFSTR(kIOHIDLocationIDKey));
+		snprintf(pathBuf, sizeof(pathBuf), "IOHIDDevice_%s_%llx_%llx_%llx",
+			transport ? transport : "unknown",
+			(long long)locationID,
+			(long long)vids[found],
+			(long long)pids[found]);
+		if (transport) free(transport);
+
+		paths[found] = strdup(pathBuf);
+		found++;
+	}
+
+	free(devices);
+	CFRelease(deviceSet);
+	IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
+	CFRelease(manager);
+
+	return found;
+}
+
+// Open a HID device by VID and PID (returns the IOHIDDeviceRef as a void pointer)
+static void* openHIDDevice(int vid, int pid) {
+	IOHIDManagerRef manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+	if (!manager) return NULL;
+
+	CFMutableDictionaryRef matchDict = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+		&kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+	CFNumberRef vidNum = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &vid);
+	CFNumberRef pidNum = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &pid);
+	CFDictionarySetValue(matchDict, CFSTR(kIOHIDVendorIDKey), vidNum);
+	CFDictionarySetValue(matchDict, CFSTR(kIOHIDProductIDKey), pidNum);
+	CFRelease(vidNum);
+	CFRelease(pidNum);
+
+	IOHIDManagerSetDeviceMatching(manager, matchDict);
+	CFRelease(matchDict);
+
+	IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
+
+	CFSetRef deviceSet = IOHIDManagerCopyDevices(manager);
+	if (!deviceSet) {
+		IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
+		CFRelease(manager);
+		return NULL;
+	}
+
+	CFIndex count = CFSetGetCount(deviceSet);
+	if (count == 0) {
+		CFRelease(deviceSet);
+		IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
+		CFRelease(manager);
+		return NULL;
+	}
+
+	const void **devices = (const void **)malloc(sizeof(void*) * count);
+	CFSetGetValues(deviceSet, devices);
+	IOHIDDeviceRef device = (IOHIDDeviceRef)devices[0];
+
+	IOReturn result = IOHIDDeviceOpen(device, kIOHIDOptionsTypeSeizeDevice);
+	free(devices);
+	CFRelease(deviceSet);
+
+	if (result != kIOReturnSuccess) {
+		IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
+		CFRelease(manager);
+		return NULL;
+	}
+
+	// We need to retain the device since the manager owns the set.
+	// Store both manager and device together.
+	// We'll use a simple struct for this.
+	CFRetain(device);
+
+	// Store the manager ref in device property for later cleanup
+	// (hack: we leak the manager to keep the device alive)
+	// A proper implementation would store both, but for simplicity
+	// we keep the manager alive by not releasing it.
+	// The caller is responsible for calling closeHIDDevice.
+
+	return (void*)device;
+}
+
+static void closeHIDDevice(void *devicePtr) {
+	if (devicePtr) {
+		IOHIDDeviceRef device = (IOHIDDeviceRef)devicePtr;
+		IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+		CFRelease(device);
+	}
+}
+
+// Send a feature report to a HID device
+// macOS IOHIDDeviceSetReport takes the report ID as a separate parameter
+static int sendHIDFeatureReport(void *devicePtr, const uint8_t *data, int length) {
+	if (!devicePtr || !data || length <= 0) return -1;
+
+	IOHIDDeviceRef device = (IOHIDDeviceRef)devicePtr;
+
+	// The report ID is the first byte of the data, per convention.
+	// On macOS, IOHIDDeviceSetReport takes the report ID separately.
+	uint8_t reportID = data[0];
+	const uint8_t *reportData = data + 1;
+	CFIndex reportLength = length - 1;
+
+	// If report ID is 0, send the entire buffer as the report
+	if (reportID == 0) {
+		reportData = data;
+		reportLength = length;
+	}
+
+	IOReturn result = IOHIDDeviceSetReport(device,
+		kIOHIDReportTypeFeature, reportID,
+		reportData, reportLength);
+
+	if (result == kIOReturnSuccess) return 0;
+
+	// Try as output report if feature report fails
+	result = IOHIDDeviceSetReport(device,
+		kIOHIDReportTypeOutput, reportID,
+		reportData, reportLength);
+
+	return (result == kIOReturnSuccess) ? 0 : -1;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+)
+
+// DeviceHandle wraps a pointer to an IOHIDDeviceRef
+type DeviceHandle uintptr
+
+// InvalidHandle represents an invalid device handle
+const InvalidHandle DeviceHandle = 0
+
+// maxEnumDevices is the maximum number of devices we enumerate at once
+const maxEnumDevices = 64
+
+// findDevicePath finds a HID device by VID, PID, and optional interface
+func findDevicePath(vid, pid uint16, targetInterface string) (string, error) {
+	devices, err := enumerateHIDDevices(int(vid), int(pid))
+	if err != nil {
+		return "", err
+	}
+
+	for _, dev := range devices {
+		if dev.VID == vid && dev.PID == pid {
+			return dev.Path, nil
+		}
+	}
+
+	return "", fmt.Errorf("device VID_%04X PID_%04X interface %s not found", vid, pid, targetInterface)
+}
+
+// autoDetectDevice tries to find any known SteelSeries device
+func autoDetectDevice(targetInterface string) (string, error) {
+	for _, known := range KnownDevices {
+		devices, err := enumerateHIDDevices(int(known.VID), int(known.PID))
+		if err != nil {
+			continue
+		}
+		for _, dev := range devices {
+			if dev.VID == known.VID && dev.PID == known.PID {
+				return dev.Path, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no known SteelSeries device found")
+}
+
+// openDevice opens a HID device by path
+// The path is expected to contain VID/PID info (from our enumeration)
+func openDevice(path string) (DeviceHandle, error) {
+	// Parse VID and PID from path (format: IOHIDDevice_transport_location_vid_pid)
+	vid, pid, err := parseDevicePath(path)
+	if err != nil {
+		return InvalidHandle, fmt.Errorf("cannot parse device path %q: %w", path, err)
+	}
+
+	ptr := C.openHIDDevice(C.int(vid), C.int(pid))
+	if ptr == nil {
+		return InvalidHandle, fmt.Errorf("failed to open device VID_%04X PID_%04X (check USB permissions)", vid, pid)
+	}
+
+	return DeviceHandle(uintptr(ptr)), nil
+}
+
+// closeDevice closes a HID device handle
+func closeDevice(handle DeviceHandle) error {
+	if handle == InvalidHandle {
+		return nil
+	}
+	C.closeHIDDevice(unsafe.Pointer(uintptr(handle)))
+	return nil
+}
+
+// sendFeatureReport sends a feature report to the HID device
+func sendFeatureReport(handle DeviceHandle, data []byte) error {
+	if handle == InvalidHandle {
+		return fmt.Errorf("invalid handle")
+	}
+
+	if len(data) == 0 {
+		return fmt.Errorf("empty data")
+	}
+
+	result := C.sendHIDFeatureReport(
+		unsafe.Pointer(uintptr(handle)),
+		(*C.uint8_t)(unsafe.Pointer(&data[0])),
+		C.int(len(data)),
+	)
+
+	if result != 0 {
+		return fmt.Errorf("failed to send feature report (IOKit error)")
+	}
+
+	return nil
+}
+
+// EnumerateDevices returns a list of all connected HID devices
+func EnumerateDevices() ([]DeviceInfo, error) {
+	return enumerateHIDDevices(-1, -1)
+}
+
+// enumerateHIDDevices enumerates HID devices, optionally filtered by VID/PID
+// Pass -1 for vid or pid to skip that filter
+func enumerateHIDDevices(filterVID, filterPID int) ([]DeviceInfo, error) {
+	var (
+		vids          [maxEnumDevices]C.int64_t
+		pids          [maxEnumDevices]C.int64_t
+		products      [maxEnumDevices]*C.char
+		manufacturers [maxEnumDevices]*C.char
+		paths         [maxEnumDevices]*C.char
+	)
+
+	count := C.enumerateHID(
+		C.int(filterVID), C.int(filterPID),
+		&vids[0], &pids[0],
+		&products[0], &manufacturers[0], &paths[0],
+		C.int(maxEnumDevices),
+	)
+
+	var result []DeviceInfo
+	for i := 0; i < int(count); i++ {
+		dev := DeviceInfo{
+			VID: uint16(vids[i]),
+			PID: uint16(pids[i]),
+		}
+
+		if products[i] != nil {
+			dev.ProductName = C.GoString(products[i])
+			C.free(unsafe.Pointer(products[i]))
+		}
+		if manufacturers[i] != nil {
+			dev.Manufacturer = C.GoString(manufacturers[i])
+			C.free(unsafe.Pointer(manufacturers[i]))
+		}
+		if paths[i] != nil {
+			dev.Path = C.GoString(paths[i])
+			C.free(unsafe.Pointer(paths[i]))
+		}
+
+		result = append(result, dev)
+	}
+
+	return result, nil
+}
+
+// parseDevicePath extracts VID and PID from our enumeration path format
+// Format: IOHIDDevice_transport_location_vid_pid
+func parseDevicePath(path string) (vid, pid int, err error) {
+	parts := strings.Split(path, "_")
+	if len(parts) < 3 {
+		return 0, 0, fmt.Errorf("invalid path format")
+	}
+
+	// The last two hex parts are VID and PID
+	var v, p int64
+	_, err = fmt.Sscanf(parts[len(parts)-2]+"_"+parts[len(parts)-1], "%x_%x", &v, &p)
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot parse VID/PID from path: %w", err)
+	}
+
+	return int(v), int(p), nil
+}

--- a/internal/driver/hid_unix.go
+++ b/internal/driver/hid_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package driver
 

--- a/internal/driver/protocol_apex_darwin.go
+++ b/internal/driver/protocol_apex_darwin.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package driver
+
+// buildApexPacket constructs the HID packet for sending pixel data on macOS.
+// macOS IOHIDDeviceSetReport takes the report ID separately from the data buffer.
+// sendHIDFeatureReport strips data[0] as the report ID before calling IOKit.
+// Format: [00 ReportID] + [61 CMD] + [pixelData] + [1 padding]
+// After stripping: device receives [61 CMD] + [pixelData] + [1 padding] = 642 bytes
+func buildApexPacket(pixelData []byte, width, height int) []byte {
+	dataSize := width * height / 8
+	packetSize := 1 + 1 + dataSize + 1 // ReportID(1) + CMD(1) + Data + Padding(1)
+
+	packet := make([]byte, packetSize)
+	packet[0] = 0x00 // Report ID (stripped by sendHIDFeatureReport before IOKit call)
+	packet[1] = 0x61 // Command byte
+
+	if len(pixelData) > dataSize {
+		copy(packet[2:], pixelData[:dataSize])
+	} else {
+		copy(packet[2:], pixelData)
+	}
+
+	return packet
+}

--- a/internal/driver/protocol_apex_darwin_test.go
+++ b/internal/driver/protocol_apex_darwin_test.go
@@ -1,0 +1,136 @@
+//go:build darwin
+
+package driver
+
+import (
+	"testing"
+)
+
+// Darwin packet format: ReportID(1) + CMD(1) + Data(640) + Padding(1) = 643 bytes
+// sendHIDFeatureReport strips ReportID; device receives CMD(1) + Data + Padding = 642 bytes
+const (
+	testPacketSize = 643 // Total packet including Report ID
+	testCmdOffset  = 1
+	testDataOffset = 2
+)
+
+func TestBuildApexPacket_Size(t *testing.T) {
+	pixelData := make([]byte, 640) // 128x40/8 = 640 bytes
+
+	packet := buildApexPacket(pixelData, 128, 40)
+
+	if len(packet) != testPacketSize {
+		t.Errorf("buildApexPacket() size = %d, want %d", len(packet), testPacketSize)
+	}
+}
+
+func TestBuildApexPacket_ReportID(t *testing.T) {
+	packet := buildApexPacket(make([]byte, 640), 128, 40)
+
+	if packet[0] != 0x00 {
+		t.Errorf("packet[0] (ReportID) = 0x%02X, want 0x00", packet[0])
+	}
+}
+
+func TestBuildApexPacket_Command(t *testing.T) {
+	packet := buildApexPacket(make([]byte, 640), 128, 40)
+
+	if packet[testCmdOffset] != 0x61 {
+		t.Errorf("packet[%d] (CMD) = 0x%02X, want 0x61", testCmdOffset, packet[testCmdOffset])
+	}
+}
+
+func TestBuildApexPacket_DataCopy(t *testing.T) {
+	pixelData := make([]byte, 640)
+	for i := range pixelData {
+		pixelData[i] = byte(i % 256)
+	}
+
+	packet := buildApexPacket(pixelData, 128, 40)
+
+	for i := 0; i < len(pixelData); i++ {
+		if packet[testDataOffset+i] != pixelData[i] {
+			t.Errorf("packet[%d] = 0x%02X, want 0x%02X", testDataOffset+i, packet[testDataOffset+i], pixelData[i])
+			break
+		}
+	}
+}
+
+func TestBuildApexPacket_ShortData(t *testing.T) {
+	pixelData := make([]byte, 100)
+	for i := range pixelData {
+		pixelData[i] = 0xFF
+	}
+
+	packet := buildApexPacket(pixelData, 128, 40)
+
+	for i := 0; i < 100; i++ {
+		if packet[testDataOffset+i] != 0xFF {
+			t.Errorf("packet[%d] = 0x%02X, want 0xFF", testDataOffset+i, packet[testDataOffset+i])
+			break
+		}
+	}
+
+	for i := 100; i < 640; i++ {
+		if packet[testDataOffset+i] != 0x00 {
+			t.Errorf("packet[%d] = 0x%02X, want 0x00 (padding)", testDataOffset+i, packet[testDataOffset+i])
+			break
+		}
+	}
+}
+
+func TestBuildApexPacket_LongData(t *testing.T) {
+	pixelData := make([]byte, 1000)
+	for i := range pixelData {
+		pixelData[i] = 0xAA
+	}
+
+	packet := buildApexPacket(pixelData, 128, 40)
+
+	if len(packet) != testPacketSize {
+		t.Errorf("buildApexPacket() size with long data = %d, want %d", len(packet), testPacketSize)
+	}
+
+	for i := 0; i < 640; i++ {
+		if packet[testDataOffset+i] != 0xAA {
+			t.Errorf("packet[%d] = 0x%02X, want 0xAA", testDataOffset+i, packet[testDataOffset+i])
+			break
+		}
+	}
+
+	if packet[642] != 0x00 {
+		t.Errorf("packet[642] (trailing padding) = 0x%02X, want 0x00", packet[642])
+	}
+}
+
+func TestBuildApexPacket_DifferentResolution(t *testing.T) {
+	width := 256
+	height := 64
+	dataSize := width * height / 8 // 2048 bytes
+
+	pixelData := make([]byte, dataSize)
+	packet := buildApexPacket(pixelData, width, height)
+
+	expected := 1 + 1 + dataSize + 1 // ReportID + CMD + Data + Padding
+	if len(packet) != expected {
+		t.Errorf("buildApexPacket() size for %dx%d = %d, want %d", width, height, len(packet), expected)
+	}
+}
+
+func BenchmarkBuildApexPacket(b *testing.B) {
+	pixelData := make([]byte, 640)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buildApexPacket(pixelData, 128, 40)
+	}
+}
+
+func BenchmarkBuildApexPacket_LargeData(b *testing.B) {
+	pixelData := make([]byte, 2048)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buildApexPacket(pixelData, 256, 64)
+	}
+}

--- a/internal/tray/notification_darwin.go
+++ b/internal/tray/notification_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package tray
+
+import (
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// ShowNotification displays a native macOS notification using osascript.
+func ShowNotification(title, message string) {
+	// Escape double quotes for AppleScript
+	safeTitle := strings.ReplaceAll(title, `"`, `\"`)
+	safeMessage := strings.ReplaceAll(message, `"`, `\"`)
+
+	script := `display notification "` + safeMessage + `" with title "` + safeTitle + `"`
+	err := exec.Command("osascript", "-e", script).Run()
+	if err != nil {
+		log.Printf("Notification (osascript failed): %s - %s: %v", title, message, err)
+	}
+}

--- a/internal/tray/notification_unix.go
+++ b/internal/tray/notification_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !darwin
 
 package tray
 

--- a/internal/widget/audiovisualizer/audio_capture_darwin.go
+++ b/internal/widget/audiovisualizer/audio_capture_darwin.go
@@ -1,0 +1,110 @@
+//go:build darwin
+
+package audiovisualizer
+
+import (
+	"log"
+	"sync"
+
+	"github.com/pozitronik/steelclock-go/internal/coreaudio"
+)
+
+// AudioCaptureDarwin captures system audio on macOS using CoreAudio aggregate device tap
+type AudioCaptureDarwin struct {
+	tap *coreaudio.AudioTap
+}
+
+var (
+	sharedAudioCapture   *AudioCaptureDarwin
+	sharedAudioCaptureMu sync.Mutex
+)
+
+// GetSharedAudioCaptureDarwin returns the shared audio capture instance
+func GetSharedAudioCaptureDarwin() (*AudioCaptureDarwin, error) {
+	sharedAudioCaptureMu.Lock()
+	defer sharedAudioCaptureMu.Unlock()
+
+	if sharedAudioCapture != nil && sharedAudioCapture.IsRunning() {
+		return sharedAudioCapture, nil
+	}
+
+	capture, err := NewAudioCaptureDarwin()
+	if err != nil {
+		return nil, err
+	}
+
+	sharedAudioCapture = capture
+	return sharedAudioCapture, nil
+}
+
+// ReinitializeSharedAudioCaptureDarwin reinitializes the shared audio capture
+func ReinitializeSharedAudioCaptureDarwin() error {
+	sharedAudioCaptureMu.Lock()
+	defer sharedAudioCaptureMu.Unlock()
+
+	if sharedAudioCapture != nil {
+		sharedAudioCapture.Close()
+		sharedAudioCapture = nil
+	}
+
+	capture, err := NewAudioCaptureDarwin()
+	if err != nil {
+		return err
+	}
+
+	sharedAudioCapture = capture
+	return nil
+}
+
+// NewAudioCaptureDarwin creates a new audio capture instance using CoreAudio tap
+func NewAudioCaptureDarwin() (*AudioCaptureDarwin, error) {
+	tap, err := coreaudio.NewAudioTap()
+	if err != nil {
+		log.Printf("[AUDIO-CAPTURE-DARWIN] Failed to create audio tap: %v", err)
+		return &AudioCaptureDarwin{}, nil // Return without error - will use demo mode
+	}
+
+	log.Printf("[AUDIO-CAPTURE-DARWIN] Audio capture started via CoreAudio tap")
+	return &AudioCaptureDarwin{tap: tap}, nil
+}
+
+// ReadSamples returns available audio samples
+func (ac *AudioCaptureDarwin) ReadSamples() (left, right []float32, err error) {
+	if ac.tap == nil {
+		return nil, nil, nil
+	}
+	return ac.tap.ReadSamples()
+}
+
+// GetRecentSamples returns the most recent N samples
+func (ac *AudioCaptureDarwin) GetRecentSamples(count int) (left, right []float32) {
+	if ac.tap == nil {
+		return nil, nil
+	}
+	return ac.tap.GetRecentSamples(count)
+}
+
+// IsRunning returns true if audio capture is active
+func (ac *AudioCaptureDarwin) IsRunning() bool {
+	if ac.tap == nil {
+		return false
+	}
+	return ac.tap.IsRunning()
+}
+
+// SampleRate returns the capture sample rate
+func (ac *AudioCaptureDarwin) SampleRate() int {
+	if ac.tap == nil {
+		return 48000 // default
+	}
+	return ac.tap.SampleRate()
+}
+
+// Close stops the audio capture
+func (ac *AudioCaptureDarwin) Close() {
+	if ac.tap != nil {
+		ac.tap.Close()
+		ac.tap = nil
+	}
+	log.Println("[AUDIO-CAPTURE-DARWIN] Stopped")
+}

--- a/internal/widget/audiovisualizer/audio_visualizer_darwin.go
+++ b/internal/widget/audiovisualizer/audio_visualizer_darwin.go
@@ -1,0 +1,692 @@
+//go:build darwin
+
+package audiovisualizer
+
+import (
+	"image"
+	"image/color"
+	"log"
+	"math"
+	"math/cmplx"
+	"sync"
+	"time"
+
+	"github.com/mjibson/go-dsp/fft"
+	"github.com/pozitronik/steelclock-go/internal/bitmap"
+	"github.com/pozitronik/steelclock-go/internal/config"
+	"github.com/pozitronik/steelclock-go/internal/widget"
+)
+
+func init() {
+	widget.Register("audio_visualizer", func(cfg config.WidgetConfig) (widget.Widget, error) {
+		return New(cfg)
+	})
+}
+
+// frequencyCompensationCurve defines frequency-dependent gain to balance spectrum display
+var frequencyCompensationCurve = []struct {
+	maxFreq float64
+	gain    float64
+}{
+	{100, 0.6},
+	{250, 0.85},
+	{500, 1.0},
+	{1000, 1.5},
+	{2000, 2.0},
+	{4000, 3.0},
+	{8000, 4.0},
+	{99999, 5.0},
+}
+
+// AudioCaptureWCA wraps AudioCaptureDarwin for API compatibility
+type AudioCaptureWCA struct {
+	capture *AudioCaptureDarwin
+}
+
+// GetSharedAudioCapture returns the shared audio capture instance
+func GetSharedAudioCapture() (*AudioCaptureWCA, error) {
+	capture, err := GetSharedAudioCaptureDarwin()
+	if err != nil {
+		return nil, err
+	}
+	return &AudioCaptureWCA{capture: capture}, nil
+}
+
+// ReinitializeSharedAudioCapture reinitializes the shared audio capture
+func ReinitializeSharedAudioCapture() error {
+	return ReinitializeSharedAudioCaptureDarwin()
+}
+
+// ReadSamples returns current audio samples
+func (ac *AudioCaptureWCA) ReadSamples() ([]float32, []float32, error) {
+	if ac.capture == nil {
+		return nil, nil, nil
+	}
+	return ac.capture.ReadSamples()
+}
+
+// Close stops audio capture
+func (ac *AudioCaptureWCA) Close() {
+	if ac.capture != nil {
+		ac.capture.Close()
+	}
+}
+
+// Widget displays real-time spectrum analyzer or oscilloscope
+type Widget struct {
+	*widget.BaseWidget
+	audioCapture *AudioCaptureDarwin
+	mu           sync.Mutex
+
+	// Display settings
+	displayMode string
+
+	// Error state management
+	errorWidget    *widget.ErrorWidget // Error widget proxy (nil = normal operation)
+	errorCount     int                 // Consecutive errors
+	errorThreshold int                 // Errors before entering error state
+	startupTime    time.Time           // For startup grace period
+
+	// Spectrum settings
+	frequencyScale         string
+	frequencyCompensation  bool
+	spectrumDynamicScaling float64
+	spectrumDynamicWindow  float64
+	smoothing              float64
+	peakHold               bool
+	peakHoldTime           float64
+	barStyle               string
+	fillColor              uint8
+	barCount               int
+
+	// Oscilloscope settings
+	sampleCount       int
+	channelMode       string
+	waveformStyle     string
+	leftChannelColor  uint8
+	rightChannelColor uint8
+
+	// Audio data buffers
+	audioData      []float32
+	audioDataLeft  []float32
+	audioDataRight []float32
+
+	// Spectrum analysis state
+	spectrumData        []float64
+	peakValues          []float64
+	peakTimestamps      []time.Time
+	smoothedValues      []float64
+	barEnergyHistory    [][]float64
+	barEnergyIndex      int
+	barEnergyWindowSize int
+	lastUpdateTime      time.Time
+}
+
+// New creates a new audio visualizer widget
+func New(cfg config.WidgetConfig) (widget.Widget, error) {
+	// Initialize audio capture
+	audioCapture, err := GetSharedAudioCaptureDarwin()
+
+	if err != nil {
+		log.Printf("[AUDIO-VIS-DARWIN] Audio capture error: %v", err)
+	} else if audioCapture != nil && audioCapture.IsRunning() {
+		log.Printf("[AUDIO-VIS-DARWIN] Real audio capture initialized")
+	} else {
+		log.Printf("[AUDIO-VIS-DARWIN] Audio capture not running")
+	}
+
+	// Set default update interval
+	if cfg.UpdateInterval <= 0 {
+		cfg.UpdateInterval = 0.033
+	}
+
+	base := widget.NewBaseWidget(cfg)
+
+	// Display mode
+	displayMode := cfg.Mode
+	if displayMode == "" {
+		displayMode = AudioDisplayModeSpectrum
+	}
+
+	// Spectrum settings
+	barCount := 32
+	frequencyScale := AudioFrequencyScaleLogarithmic
+	frequencyCompensation := true
+	spectrumDynamicScaling := 0.0
+	spectrumDynamicWindow := 0.5
+	smoothing := 0.5
+	barStyle := AudioBarStyleBars
+
+	if cfg.Spectrum != nil {
+		if cfg.Spectrum.Bars > 0 {
+			barCount = cfg.Spectrum.Bars
+		}
+		if cfg.Spectrum.Scale != "" {
+			frequencyScale = cfg.Spectrum.Scale
+		}
+		frequencyCompensation = cfg.Spectrum.FrequencyCompensation
+		if cfg.Spectrum.Smoothing > 0 {
+			smoothing = cfg.Spectrum.Smoothing
+		}
+		if cfg.Spectrum.Style != "" {
+			barStyle = cfg.Spectrum.Style
+		}
+		if cfg.Spectrum.DynamicScaling != nil {
+			if cfg.Spectrum.DynamicScaling.Strength > 0 {
+				spectrumDynamicScaling = cfg.Spectrum.DynamicScaling.Strength
+			}
+			if cfg.Spectrum.DynamicScaling.Window > 0 {
+				spectrumDynamicWindow = cfg.Spectrum.DynamicScaling.Window
+			}
+		}
+	}
+
+	if barCount > cfg.Position.W {
+		barCount = cfg.Position.W
+	}
+
+	// Peak settings
+	peakHold := true
+	peakHoldTime := 1.0
+
+	if cfg.Spectrum != nil && cfg.Spectrum.Peak != nil {
+		peakHold = cfg.Spectrum.Peak.Enabled
+		if cfg.Spectrum.Peak.HoldTime > 0 {
+			peakHoldTime = cfg.Spectrum.Peak.HoldTime
+		}
+	}
+
+	// Oscilloscope settings
+	sampleCount := 256
+	channelMode := AudioChannelModeMono
+	waveformStyle := AudioWaveformStyleLine
+
+	if cfg.Oscilloscope != nil {
+		if cfg.Oscilloscope.Samples > 0 {
+			sampleCount = cfg.Oscilloscope.Samples
+		}
+		if cfg.Oscilloscope.Style != "" {
+			waveformStyle = cfg.Oscilloscope.Style
+		}
+	}
+
+	if cfg.Channel != "" {
+		channelMode = cfg.Channel
+	}
+
+	// Colors
+	fillColor := 255
+	leftChannelColor := 255
+	rightChannelColor := 200
+
+	switch displayMode {
+	case AudioDisplayModeSpectrum:
+		if cfg.Spectrum != nil && cfg.Spectrum.Colors != nil {
+			if cfg.Spectrum.Colors.Fill != nil {
+				fillColor = *cfg.Spectrum.Colors.Fill
+			}
+			if cfg.Spectrum.Colors.Left != nil {
+				leftChannelColor = *cfg.Spectrum.Colors.Left
+			}
+			if cfg.Spectrum.Colors.Right != nil {
+				rightChannelColor = *cfg.Spectrum.Colors.Right
+			}
+		}
+	case AudioDisplayModeOscilloscope:
+		if cfg.Oscilloscope != nil && cfg.Oscilloscope.Colors != nil {
+			if cfg.Oscilloscope.Colors.Fill != nil {
+				fillColor = *cfg.Oscilloscope.Colors.Fill
+			}
+			if cfg.Oscilloscope.Colors.Left != nil {
+				leftChannelColor = *cfg.Oscilloscope.Colors.Left
+			}
+			if cfg.Oscilloscope.Colors.Right != nil {
+				rightChannelColor = *cfg.Oscilloscope.Colors.Right
+			}
+		}
+	}
+
+	windowSize := int(spectrumDynamicWindow/cfg.UpdateInterval) + 1
+	if windowSize < 2 {
+		windowSize = 2
+	}
+
+	energyHistory := make([][]float64, barCount)
+	for i := range energyHistory {
+		energyHistory[i] = make([]float64, windowSize)
+	}
+
+	w := &Widget{
+		BaseWidget:             base,
+		audioCapture:           audioCapture,
+		displayMode:            displayMode,
+		frequencyScale:         frequencyScale,
+		frequencyCompensation:  frequencyCompensation,
+		spectrumDynamicScaling: spectrumDynamicScaling,
+		spectrumDynamicWindow:  spectrumDynamicWindow,
+		smoothing:              smoothing,
+		peakHold:               peakHold,
+		peakHoldTime:           peakHoldTime,
+		barStyle:               barStyle,
+		fillColor:              uint8(fillColor),
+		barCount:               barCount,
+		sampleCount:            sampleCount,
+		channelMode:            channelMode,
+		waveformStyle:          waveformStyle,
+		leftChannelColor:       uint8(leftChannelColor),
+		rightChannelColor:      uint8(rightChannelColor),
+		spectrumData:           make([]float64, barCount),
+		peakValues:             make([]float64, barCount),
+		peakTimestamps:         make([]time.Time, barCount),
+		smoothedValues:         make([]float64, barCount),
+		barEnergyHistory:       energyHistory,
+		barEnergyIndex:         0,
+		barEnergyWindowSize:    windowSize,
+		audioData:              make([]float32, 0, 4096),
+		audioDataLeft:          make([]float32, 0, 4096),
+		audioDataRight:         make([]float32, 0, 4096),
+		errorThreshold:         30, // ~1 second at 30fps
+		startupTime:            time.Now(),
+	}
+
+	// Enter error state immediately if audio capture failed to initialize
+	if audioCapture == nil || !audioCapture.IsRunning() {
+		if err != nil {
+			pos := w.GetPosition()
+			w.errorWidget = widget.NewErrorWidget(pos.W, pos.H, "NO AUDIO")
+			log.Printf("[AUDIO-VIS-DARWIN] Entering error state: audio capture unavailable")
+		}
+	}
+
+	return w, nil
+}
+
+// Update reads audio data and updates visualization
+func (w *Widget) Update() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Delegate to error widget if in error state
+	if w.errorWidget != nil {
+		return w.errorWidget.Update()
+	}
+
+	w.lastUpdateTime = time.Now()
+
+	// Check audio capture health
+	if w.audioCapture == nil || !w.audioCapture.IsRunning() {
+		// Grace period: don't count errors during startup (audio tools may take time)
+		if time.Since(w.startupTime) > 3*time.Second {
+			w.errorCount++
+			if w.errorCount >= w.errorThreshold {
+				pos := w.GetPosition()
+				w.errorWidget = widget.NewErrorWidget(pos.W, pos.H, "NO AUDIO")
+				log.Printf("[AUDIO-VIS-DARWIN] Entering error state after %d consecutive failures", w.errorCount)
+			}
+		}
+		return nil
+	}
+
+	// Reset error count on successful capture access
+	w.errorCount = 0
+
+	left, right := w.audioCapture.GetRecentSamples(4096)
+	if len(left) == 0 {
+		return nil
+	}
+
+	// Combine stereo to mono for spectrum analysis
+	samples := make([]float32, len(left))
+	for i := range left {
+		samples[i] = (left[i] + right[i]) / 2.0
+	}
+
+	// Update audio buffers
+	maxSamples := 8192
+	w.audioData = append(w.audioData, samples...)
+	if len(w.audioData) > maxSamples {
+		w.audioData = w.audioData[len(w.audioData)-maxSamples:]
+	}
+
+	w.audioDataLeft = append(w.audioDataLeft, left...)
+	w.audioDataRight = append(w.audioDataRight, right...)
+	if len(w.audioDataLeft) > maxSamples {
+		w.audioDataLeft = w.audioDataLeft[len(w.audioDataLeft)-maxSamples:]
+		w.audioDataRight = w.audioDataRight[len(w.audioDataRight)-maxSamples:]
+	}
+
+	// Process for spectrum mode
+	if w.displayMode == AudioDisplayModeSpectrum && len(w.audioData) >= 2048 {
+		w.updateSpectrum(w.audioData)
+	}
+
+	return nil
+}
+
+// updateSpectrum performs FFT and updates spectrum data
+func (w *Widget) updateSpectrum(samples []float32) {
+	fftSize := 2048
+	if len(samples) < fftSize {
+		return
+	}
+
+	fftSamples := samples[len(samples)-fftSize:]
+
+	// Remove DC offset
+	var mean float32
+	for _, s := range fftSamples {
+		mean += s
+	}
+	mean /= float32(len(fftSamples))
+
+	// Convert to complex and apply window
+	input := make([]complex128, fftSize)
+	for i := 0; i < fftSize; i++ {
+		sample := float64(fftSamples[i] - mean)
+		window := 0.5 * (1 - math.Cos(2*math.Pi*float64(i)/float64(fftSize-1)))
+		input[i] = complex(sample*window, 0)
+	}
+
+	// Perform FFT
+	output := fft.FFT(input)
+
+	// Calculate magnitudes
+	halfSize := fftSize / 2
+	magnitudes := make([]float64, halfSize)
+
+	for i := 0; i < halfSize; i++ {
+		magnitudes[i] = cmplx.Abs(output[i]) / float64(fftSize)
+	}
+	magnitudes[0] = 0.0 // Zero DC
+
+	// Normalize
+	maxRawMag := 0.0
+	for i := 1; i < halfSize; i++ {
+		if magnitudes[i] > maxRawMag {
+			maxRawMag = magnitudes[i]
+		}
+	}
+
+	if maxRawMag > 0.0001 {
+		targetMax := 0.75
+		normFactor := targetMax / maxRawMag
+		for i := 0; i < halfSize; i++ {
+			magnitudes[i] = math.Min(1.0, magnitudes[i]*normFactor)
+		}
+	}
+
+	// Map to bars
+	barCount := len(w.spectrumData)
+	if w.frequencyScale == AudioFrequencyScaleLogarithmic {
+		w.mapFrequenciesLogarithmic(magnitudes, barCount)
+	} else {
+		w.mapFrequenciesLinear(magnitudes, barCount)
+	}
+
+	// Store energy history
+	for i := 0; i < barCount; i++ {
+		w.barEnergyHistory[i][w.barEnergyIndex] = w.spectrumData[i]
+	}
+	w.barEnergyIndex = (w.barEnergyIndex + 1) % w.barEnergyWindowSize
+
+	// Apply smoothing
+	dt := time.Since(w.lastUpdateTime).Seconds()
+	if dt > 0 && w.smoothing > 0 {
+		for i := range w.smoothedValues {
+			alpha := 1.0 - math.Pow(w.smoothing, dt*30)
+			w.smoothedValues[i] = alpha*w.spectrumData[i] + (1-alpha)*w.smoothedValues[i]
+		}
+	} else {
+		copy(w.smoothedValues, w.spectrumData)
+	}
+
+	// Update peak hold
+	if w.peakHold {
+		now := time.Now()
+		for i := range w.peakValues {
+			if w.smoothedValues[i] > w.peakValues[i] {
+				w.peakValues[i] = w.smoothedValues[i]
+				w.peakTimestamps[i] = now
+			} else {
+				elapsed := now.Sub(w.peakTimestamps[i]).Seconds()
+				if elapsed > w.peakHoldTime {
+					decayRate := 0.3
+					dt := time.Since(w.lastUpdateTime).Seconds()
+					w.peakValues[i] *= 1.0 - decayRate*dt
+					if w.peakValues[i] < w.smoothedValues[i] {
+						w.peakValues[i] = w.smoothedValues[i]
+					}
+					if w.peakValues[i] < 0.01 {
+						w.peakValues[i] = 0
+					}
+				}
+			}
+		}
+	}
+}
+
+// mapFrequenciesLogarithmic maps FFT bins to bars using logarithmic scale
+func (w *Widget) mapFrequenciesLogarithmic(magnitudes []float64, barCount int) {
+	minFreq := 40.0
+	maxFreq := 20000.0
+	sampleRate := 48000.0
+	freqPerBin := sampleRate / float64(len(magnitudes)*2)
+
+	for i := 0; i < barCount; i++ {
+		ratio := float64(i) / float64(barCount)
+		freqStart := minFreq * math.Pow(maxFreq/minFreq, ratio)
+		freqEnd := minFreq * math.Pow(maxFreq/minFreq, (float64(i+1))/float64(barCount))
+
+		binStart := int(freqStart / freqPerBin)
+		binEnd := int(freqEnd / freqPerBin)
+
+		if binEnd >= len(magnitudes) {
+			binEnd = len(magnitudes) - 1
+		}
+		if binStart >= len(magnitudes) {
+			binStart = len(magnitudes) - 1
+		}
+
+		peakValue := 0.0
+		for j := binStart; j <= binEnd && j < len(magnitudes); j++ {
+			if magnitudes[j] > peakValue {
+				peakValue = magnitudes[j]
+			}
+		}
+
+		if w.frequencyCompensation {
+			centerFreq := (freqStart + freqEnd) / 2.0
+			for _, curve := range frequencyCompensationCurve {
+				if centerFreq < curve.maxFreq {
+					peakValue = math.Min(1.0, peakValue*curve.gain)
+					break
+				}
+			}
+		}
+
+		w.spectrumData[i] = peakValue
+	}
+}
+
+// mapFrequenciesLinear maps FFT bins to bars using linear scale
+func (w *Widget) mapFrequenciesLinear(magnitudes []float64, barCount int) {
+	binsPerBar := len(magnitudes) / barCount
+	sampleRate := 48000.0
+	freqPerBin := sampleRate / float64(len(magnitudes)*2)
+
+	for i := 0; i < barCount; i++ {
+		start := i * binsPerBar
+		end := start + binsPerBar
+		if end > len(magnitudes) {
+			end = len(magnitudes)
+		}
+
+		peakValue := 0.0
+		for j := start; j < end; j++ {
+			if magnitudes[j] > peakValue {
+				peakValue = magnitudes[j]
+			}
+		}
+
+		if w.frequencyCompensation {
+			centerFreq := (float64(start) + float64(end)) / 2.0 * freqPerBin
+			for _, curve := range frequencyCompensationCurve {
+				if centerFreq < curve.maxFreq {
+					peakValue = math.Min(1.0, peakValue*curve.gain)
+					break
+				}
+			}
+		}
+
+		w.spectrumData[i] = peakValue
+	}
+}
+
+// Render draws the visualization
+func (w *Widget) Render() (image.Image, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Delegate to error widget if in error state
+	if w.errorWidget != nil {
+		return w.errorWidget.Render()
+	}
+
+	// Create canvas with background
+	img := w.CreateCanvas()
+
+	if w.displayMode == AudioDisplayModeSpectrum {
+		w.renderSpectrum(img)
+	} else if w.displayMode == AudioDisplayModeOscilloscope {
+		w.renderOscilloscope(img)
+	}
+
+	w.ApplyBorder(img)
+
+	return img, nil
+}
+
+// renderSpectrum draws spectrum analyzer bars
+func (w *Widget) renderSpectrum(img *image.Gray) {
+	barCount := len(w.spectrumData)
+	if barCount == 0 {
+		return
+	}
+
+	pos := w.GetPosition()
+	width := pos.W
+	height := pos.H
+	barWidth := width / barCount
+	gap := 0
+	if w.barStyle == AudioBarStyleBars && barWidth > 2 {
+		gap = 1
+	}
+
+	for i := 0; i < barCount; i++ {
+		magnitude := w.smoothedValues[i]
+		if magnitude > 1.0 {
+			magnitude = 1.0
+		}
+		if magnitude < 0.0 {
+			magnitude = 0.0
+		}
+
+		barHeight := int(magnitude * float64(height))
+		if barHeight > height {
+			barHeight = height
+		}
+
+		x := i * barWidth
+		y := height - barHeight
+
+		if w.barStyle == AudioBarStyleBars {
+			for py := y; py < height; py++ {
+				for px := x; px < x+barWidth-gap && px < width; px++ {
+					img.SetGray(px, py, color.Gray{Y: w.fillColor})
+				}
+			}
+		} else {
+			for px := x; px < x+barWidth && px < width; px++ {
+				if y >= 0 && y < height {
+					img.SetGray(px, y, color.Gray{Y: w.fillColor})
+				}
+			}
+		}
+
+		// Peak hold
+		if w.peakHold && i < len(w.peakValues) {
+			peakMagnitude := w.peakValues[i]
+			if peakMagnitude > 1.0 {
+				peakMagnitude = 1.0
+			}
+			if peakMagnitude < 0.0 {
+				peakMagnitude = 0.0
+			}
+			peakY := height - int(peakMagnitude*float64(height))
+			if peakY >= 0 && peakY < height {
+				for px := x; px < x+barWidth-gap && px < width; px++ {
+					img.SetGray(px, peakY, color.Gray{Y: w.fillColor})
+				}
+			}
+		}
+	}
+}
+
+// renderOscilloscope draws waveform
+func (w *Widget) renderOscilloscope(img *image.Gray) {
+	pos := w.GetPosition()
+	height := pos.H
+	width := pos.W
+	sampleCount := w.sampleCount
+
+	if len(w.audioData) == 0 {
+		return
+	}
+	if sampleCount > len(w.audioData) {
+		sampleCount = len(w.audioData)
+	}
+
+	centerY := height / 2
+	samples := w.audioData[len(w.audioData)-sampleCount:]
+
+	amplitude := float32(height) / 2.0
+
+	for i := 0; i < sampleCount-1; i++ {
+		x1 := i * width / sampleCount
+		x2 := (i + 1) * width / sampleCount
+
+		y1 := centerY - int(samples[i]*amplitude)
+		y2 := centerY - int(samples[i+1]*amplitude)
+
+		if y1 < 0 {
+			y1 = 0
+		}
+		if y1 >= height {
+			y1 = height - 1
+		}
+		if y2 < 0 {
+			y2 = 0
+		}
+		if y2 >= height {
+			y2 = height - 1
+		}
+
+		if w.waveformStyle == AudioWaveformStyleLine {
+			bitmap.DrawLine(img, x1, y1, x2, y2, color.Gray{Y: w.fillColor})
+		} else if w.waveformStyle == AudioWaveformStyleFilled {
+			if y1 < centerY {
+				for y := y1; y <= centerY && y < height; y++ {
+					if x1 >= 0 && x1 < width {
+						img.SetGray(x1, y, color.Gray{Y: w.fillColor})
+					}
+				}
+			} else {
+				for y := centerY; y <= y1 && y < height; y++ {
+					if x1 >= 0 && x1 < width {
+						img.SetGray(x1, y, color.Gray{Y: w.fillColor})
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/widget/audiovisualizer/audio_visualizer_stub.go
+++ b/internal/widget/audiovisualizer/audio_visualizer_stub.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package audiovisualizer
 

--- a/internal/widget/audiovisualizer/audio_visualizer_stub_test.go
+++ b/internal/widget/audiovisualizer/audio_visualizer_stub_test.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package audiovisualizer
 

--- a/internal/widget/battery/battery_darwin.go
+++ b/internal/widget/battery/battery_darwin.go
@@ -1,0 +1,114 @@
+//go:build darwin
+
+package battery
+
+import (
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// getBatteryStatus returns the current battery status on macOS using ioreg
+func getBatteryStatus() (Status, error) {
+	result := Status{}
+
+	// Use ioreg to read AppleSmartBattery properties
+	out, err := exec.Command("ioreg", "-rc", "AppleSmartBattery").Output()
+	if err != nil {
+		// No battery (e.g., desktop Mac)
+		result.HasBattery = false
+		return result, nil
+	}
+
+	output := string(out)
+
+	// Check if battery exists
+	if !strings.Contains(output, "AppleSmartBattery") {
+		result.HasBattery = false
+		return result, nil
+	}
+
+	result.HasBattery = true
+
+	// Parse battery properties from ioreg output
+	result.Percentage = readIoregInt(output, "CurrentCapacity")
+	maxCapacity := readIoregInt(output, "MaxCapacity")
+
+	// If CurrentCapacity is raw, calculate percentage
+	if maxCapacity > 0 && result.Percentage > 0 && maxCapacity != 100 {
+		result.Percentage = result.Percentage * 100 / maxCapacity
+	}
+
+	// Clamp percentage
+	if result.Percentage > 100 {
+		result.Percentage = 100
+	}
+	if result.Percentage < 0 {
+		result.Percentage = 0
+	}
+
+	// Charging state
+	result.IsCharging = readIoregBool(output, "IsCharging")
+	result.IsPluggedIn = readIoregBool(output, "ExternalConnected")
+
+	// Time to empty/full (ioreg reports in minutes)
+	timeToEmpty := readIoregInt(output, "AvgTimeToEmpty")
+	if timeToEmpty > 0 && timeToEmpty < 65535 { // 65535 means not discharging
+		result.TimeToEmpty = timeToEmpty
+	}
+
+	timeToFull := readIoregInt(output, "AvgTimeToFull")
+	if timeToFull > 0 && timeToFull < 65535 { // 65535 means not charging
+		result.TimeToFull = timeToFull
+	}
+
+	// Check Low Power Mode
+	result.IsEconomyMode = isPowerSavingMode()
+
+	return result, nil
+}
+
+// isPowerSavingMode checks if Low Power Mode is active on macOS
+func isPowerSavingMode() bool {
+	out, err := exec.Command("pmset", "-g").Output()
+	if err != nil {
+		return false
+	}
+	// Look for "lowpowermode 1" in pmset output
+	return strings.Contains(string(out), "lowpowermode            1") ||
+		strings.Contains(string(out), "lowpowermode\t\t\t1")
+}
+
+var ioregIntRegex = regexp.MustCompile(`=\s*(\d+)`)
+var ioregBoolRegex = regexp.MustCompile(`=\s*(Yes|No)`)
+
+// readIoregInt reads an integer property from ioreg output
+func readIoregInt(output, key string) int {
+	// Find the line containing the key
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "\""+key+"\"") {
+			matches := ioregIntRegex.FindStringSubmatch(line)
+			if len(matches) > 1 {
+				val, err := strconv.Atoi(matches[1])
+				if err == nil {
+					return val
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// readIoregBool reads a boolean property from ioreg output
+func readIoregBool(output, key string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "\""+key+"\"") {
+			matches := ioregBoolRegex.FindStringSubmatch(line)
+			if len(matches) > 1 {
+				return matches[1] == "Yes"
+			}
+		}
+	}
+	return false
+}

--- a/internal/widget/clipboard/clipboard_darwin.go
+++ b/internal/widget/clipboard/clipboard_darwin.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package clipboard
+
+import (
+	"crypto/md5"
+	"os/exec"
+	"strings"
+)
+
+// darwinReader reads clipboard content via pbpaste on macOS.
+type darwinReader struct {
+	lastHash [md5.Size]byte
+}
+
+// newReader creates a clipboard reader for macOS using pbpaste.
+func newReader() (Reader, error) {
+	return &darwinReader{}, nil
+}
+
+// HasChanged returns true if the clipboard content has changed since the last Read.
+func (r *darwinReader) HasChanged() bool {
+	content, _, _ := r.readClipboard()
+	hash := md5.Sum([]byte(content))
+	return hash != r.lastHash
+}
+
+// Read returns the current clipboard content and its type.
+func (r *darwinReader) Read() (string, ContentType, error) {
+	content, contentType, err := r.readClipboard()
+	if err != nil {
+		return "", TypeUnknown, err
+	}
+	r.lastHash = md5.Sum([]byte(content))
+	return content, contentType, nil
+}
+
+// Close is a no-op on macOS (no resources to release).
+func (r *darwinReader) Close() error {
+	return nil
+}
+
+// readClipboard reads the clipboard using pbpaste and determines content type.
+func (r *darwinReader) readClipboard() (string, ContentType, error) {
+	out, err := exec.Command("pbpaste").Output()
+	if err != nil {
+		return "", TypeEmpty, nil
+	}
+
+	content := string(out)
+	if content == "" {
+		return "", TypeEmpty, nil
+	}
+
+	// Detect content type
+	contentType := detectContentType(content)
+	return content, contentType, nil
+}
+
+// detectContentType attempts to classify the clipboard content.
+func detectContentType(content string) ContentType {
+	trimmed := strings.TrimSpace(content)
+
+	if trimmed == "" {
+		return TypeEmpty
+	}
+
+	// Check for HTML content
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "<!doctype") || strings.HasPrefix(lower, "<html") {
+		return TypeHTML
+	}
+
+	// Check for file paths (macOS paths start with /)
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) > 0 && strings.HasPrefix(lines[0], "/") {
+		allPaths := true
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line != "" && !strings.HasPrefix(line, "/") {
+				allPaths = false
+				break
+			}
+		}
+		if allPaths {
+			return TypeFiles
+		}
+	}
+
+	return TypeText
+}

--- a/internal/widget/clipboard/clipboard_stub.go
+++ b/internal/widget/clipboard/clipboard_stub.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package clipboard
 

--- a/internal/widget/keyboard/keyboard_darwin.go
+++ b/internal/widget/keyboard/keyboard_darwin.go
@@ -1,0 +1,49 @@
+//go:build darwin
+
+package keyboard
+
+import (
+	"image"
+
+	"github.com/pozitronik/steelclock-go/internal/config"
+	"github.com/pozitronik/steelclock-go/internal/widget"
+)
+
+func init() {
+	widget.Register("keyboard", func(cfg config.WidgetConfig) (widget.Widget, error) {
+		return New(cfg)
+	})
+}
+
+// Widget stub for macOS - displays error via ErrorWidget
+type Widget struct {
+	*widget.BaseWidget
+	errorWidget *widget.ErrorWidget
+}
+
+// New creates a stub widget that displays unsupported message
+func New(cfg config.WidgetConfig) (*Widget, error) {
+	base := widget.NewBaseWidget(cfg)
+	pos := base.GetPosition()
+
+	return &Widget{
+		BaseWidget:  base,
+		errorWidget: widget.NewErrorWidget(pos.W, pos.H, "UNSUPPORTED"),
+	}, nil
+}
+
+// Update delegates to error widget
+func (w *Widget) Update() error {
+	if w.errorWidget != nil {
+		return w.errorWidget.Update()
+	}
+	return nil
+}
+
+// Render delegates to error widget
+func (w *Widget) Render() (image.Image, error) {
+	if w.errorWidget != nil {
+		return w.errorWidget.Render()
+	}
+	return nil, nil
+}

--- a/internal/widget/keyboardlayout/keyboardlayout_darwin.go
+++ b/internal/widget/keyboardlayout/keyboardlayout_darwin.go
@@ -1,0 +1,49 @@
+//go:build darwin
+
+package keyboardlayout
+
+import (
+	"image"
+
+	"github.com/pozitronik/steelclock-go/internal/config"
+	"github.com/pozitronik/steelclock-go/internal/widget"
+)
+
+func init() {
+	widget.Register("keyboard_layout", func(cfg config.WidgetConfig) (widget.Widget, error) {
+		return New(cfg)
+	})
+}
+
+// Widget stub for macOS - displays error via ErrorWidget
+type Widget struct {
+	*widget.BaseWidget
+	errorWidget *widget.ErrorWidget
+}
+
+// New creates a stub widget that displays unsupported message
+func New(cfg config.WidgetConfig) (*Widget, error) {
+	base := widget.NewBaseWidget(cfg)
+	pos := base.GetPosition()
+
+	return &Widget{
+		BaseWidget:  base,
+		errorWidget: widget.NewErrorWidget(pos.W, pos.H, "UNSUPPORTED"),
+	}, nil
+}
+
+// Update delegates to error widget
+func (w *Widget) Update() error {
+	if w.errorWidget != nil {
+		return w.errorWidget.Update()
+	}
+	return nil
+}
+
+// Render delegates to error widget
+func (w *Widget) Render() (image.Image, error) {
+	if w.errorWidget != nil {
+		return w.errorWidget.Render()
+	}
+	return nil, nil
+}

--- a/internal/widget/volume/volume_darwin.go
+++ b/internal/widget/volume/volume_darwin.go
@@ -1,0 +1,146 @@
+//go:build darwin
+
+package volume
+
+/*
+#cgo LDFLAGS: -framework CoreAudio
+
+#include <CoreAudio/CoreAudio.h>
+
+// getDefaultOutputDeviceID returns the default output audio device ID
+static AudioDeviceID getDefaultOutputDeviceID() {
+	AudioDeviceID deviceID = kAudioObjectUnknown;
+	UInt32 size = sizeof(deviceID);
+	AudioObjectPropertyAddress addr = {
+		kAudioHardwarePropertyDefaultOutputDevice,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMain
+	};
+	OSStatus err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, &deviceID);
+	if (err != noErr) return kAudioObjectUnknown;
+	return deviceID;
+}
+
+// getVolumeScalar returns the volume scalar (0.0-1.0) for the given device
+// Tries master channel first, then averages L/R
+static float getVolumeScalar(AudioDeviceID deviceID) {
+	Float32 volume = 0.0;
+	UInt32 size = sizeof(volume);
+
+	// Try master channel (element 0)
+	AudioObjectPropertyAddress addr = {
+		kAudioDevicePropertyVolumeScalar,
+		kAudioDevicePropertyScopeOutput,
+		kAudioObjectPropertyElementMain
+	};
+
+	OSStatus err = AudioObjectGetPropertyData(deviceID, &addr, 0, NULL, &size, &volume);
+	if (err == noErr) return volume;
+
+	// Fallback: average L (element 1) and R (element 2)
+	Float32 left = 0.0, right = 0.0;
+	addr.mElement = 1;
+	err = AudioObjectGetPropertyData(deviceID, &addr, 0, NULL, &size, &left);
+	if (err != noErr) return -1.0;
+
+	addr.mElement = 2;
+	err = AudioObjectGetPropertyData(deviceID, &addr, 0, NULL, &size, &right);
+	if (err != noErr) return left; // mono device
+
+	return (left + right) / 2.0;
+}
+
+// getMuteState returns 1 if muted, 0 if not, -1 on error
+static int getMuteState(AudioDeviceID deviceID) {
+	UInt32 muted = 0;
+	UInt32 size = sizeof(muted);
+
+	// Try master channel
+	AudioObjectPropertyAddress addr = {
+		kAudioDevicePropertyMute,
+		kAudioDevicePropertyScopeOutput,
+		kAudioObjectPropertyElementMain
+	};
+
+	OSStatus err = AudioObjectGetPropertyData(deviceID, &addr, 0, NULL, &size, &muted);
+	if (err == noErr) return (int)muted;
+
+	// Fallback: check channel 1
+	addr.mElement = 1;
+	err = AudioObjectGetPropertyData(deviceID, &addr, 0, NULL, &size, &muted);
+	if (err == noErr) return (int)muted;
+
+	return 0; // Assume not muted if we can't read it
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+// DarwinReader reads system volume using CoreAudio
+type DarwinReader struct {
+	mu sync.Mutex
+}
+
+// NewDarwinReader creates a new macOS volume reader
+func NewDarwinReader() (*DarwinReader, error) {
+	// Verify we can get the default output device
+	deviceID := C.getDefaultOutputDeviceID()
+	if deviceID == C.kAudioObjectUnknown {
+		return nil, fmt.Errorf("no default audio output device found")
+	}
+
+	log.Printf("[VOLUME-DARWIN] Using CoreAudio")
+	return &DarwinReader{}, nil
+}
+
+// GetVolume reads the current master volume level (0-100) and mute status
+func (r *DarwinReader) GetVolume() (volume float64, muted bool, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	deviceID := C.getDefaultOutputDeviceID()
+	if deviceID == C.kAudioObjectUnknown {
+		return 0, false, fmt.Errorf("no default audio output device")
+	}
+
+	vol := C.getVolumeScalar(deviceID)
+	if vol < 0 {
+		return 0, false, fmt.Errorf("failed to read volume scalar")
+	}
+
+	muteState := C.getMuteState(deviceID)
+
+	return float64(vol) * 100.0, muteState == 1, nil
+}
+
+// Close releases resources (no-op for CoreAudio property queries)
+func (r *DarwinReader) Close() {}
+
+// Reinitialize re-checks the default output device
+func (r *DarwinReader) Reinitialize() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	deviceID := C.getDefaultOutputDeviceID()
+	if deviceID == C.kAudioObjectUnknown {
+		return fmt.Errorf("no default audio output device after reinitialization")
+	}
+
+	log.Printf("[VOLUME-DARWIN] Reinitialized with CoreAudio")
+	return nil
+}
+
+// NeedsReinitialize returns false - CoreAudio handles device switching transparently
+func (r *DarwinReader) NeedsReinitialize() bool {
+	return false
+}
+
+// newVolumeReader creates a platform-specific volume reader (macOS implementation)
+func newVolumeReader() (Reader, error) {
+	return NewDarwinReader()
+}

--- a/internal/widget/volume/volume_stub.go
+++ b/internal/widget/volume/volume_stub.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package volume
 

--- a/internal/widget/volumemeter/volume_meter_darwin.go
+++ b/internal/widget/volumemeter/volume_meter_darwin.go
@@ -1,0 +1,103 @@
+//go:build darwin
+
+package volumemeter
+
+import (
+	"log"
+	"sync"
+
+	"github.com/pozitronik/steelclock-go/internal/coreaudio"
+)
+
+// DarwinMeterReader reads audio meter data on macOS using CoreAudio aggregate device tap
+type DarwinMeterReader struct {
+	mu  sync.Mutex
+	tap *coreaudio.AudioTap
+}
+
+// NewDarwinMeterReader creates a new macOS meter reader
+func NewDarwinMeterReader() (*DarwinMeterReader, error) {
+	tap, err := coreaudio.NewAudioTap()
+	if err != nil {
+		log.Printf("[METER-DARWIN] Failed to create audio tap: %v", err)
+		// Return reader without tap - will return silence
+		return &DarwinMeterReader{}, nil
+	}
+
+	log.Printf("[METER-DARWIN] Using CoreAudio aggregate device tap")
+	return &DarwinMeterReader{tap: tap}, nil
+}
+
+// GetMeterData reads current audio meter values from the tap's peak levels
+func (r *DarwinMeterReader) GetMeterData(clippingThreshold, silenceThreshold float64) (*MeterData, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.tap == nil || !r.tap.IsRunning() {
+		return &MeterData{
+			Peak:         0,
+			ChannelPeaks: []float64{0, 0},
+			ChannelCount: 2,
+			IsClipping:   false,
+			HasAudio:     false,
+		}, nil
+	}
+
+	left, right := r.tap.GetPeakLevels()
+	peak := left
+	if right > peak {
+		peak = right
+	}
+
+	return &MeterData{
+		Peak:         peak,
+		ChannelPeaks: []float64{left, right},
+		ChannelCount: 2,
+		IsClipping:   peak >= clippingThreshold,
+		HasAudio:     peak > silenceThreshold,
+	}, nil
+}
+
+// Close releases the audio tap
+func (r *DarwinMeterReader) Close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.tap != nil {
+		r.tap.Close()
+		r.tap = nil
+	}
+}
+
+// Reinitialize recreates the audio tap
+func (r *DarwinMeterReader) Reinitialize() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.tap != nil {
+		r.tap.Close()
+	}
+
+	tap, err := coreaudio.NewAudioTap()
+	if err != nil {
+		r.tap = nil
+		return err
+	}
+
+	r.tap = tap
+	log.Printf("[METER-DARWIN] Reinitialized with CoreAudio tap")
+	return nil
+}
+
+// NeedsReinitialize returns true if the tap is no longer running
+func (r *DarwinMeterReader) NeedsReinitialize() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.tap != nil && !r.tap.IsRunning()
+}
+
+// newMeterReader creates a platform-specific meter reader (macOS implementation)
+func newMeterReader() (Reader, error) {
+	return NewDarwinMeterReader()
+}

--- a/internal/widget/volumemeter/volume_meter_stub.go
+++ b/internal/widget/volumemeter/volume_meter_stub.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !darwin
 
 package volumemeter
 


### PR DESCRIPTION
## Summary

- **Added** `internal/driver/protocol_apex_darwin.go` — implements `buildApexPacket` for macOS, fixing the build error `undefined: buildApexPacket` introduced when the darwin port was added in `89dfe16`
- **Fixed** `internal/driver/hid_darwin.go` — removed the buggy `reportID == 0` branch in `sendHIDFeatureReport` that sent the full buffer (including the placeholder `0x00`) to `IOHIDDeviceSetReport`
- **Added** `internal/driver/protocol_apex_darwin_test.go` — mirrors the Linux/Windows test suite for the darwin packet format (7 tests, all passing)

## What changed and why

The darwin port was missing `protocol_apex_darwin.go`, so `buildApexPacket` was undefined on macOS and the build failed immediately.

The Darwin packet uses the same Windows-style layout:
```
[0x00 ReportID] + [0x61 CMD] + [pixelData] + [1 padding]
```
`sendHIDFeatureReport` always strips `data[0]` as the report ID before calling `IOHIDDeviceSetReport`. After stripping, IOKit receives `reportID=0` and a 642-byte buffer `[0x61, pixelData..., padding]` — exactly what the Apex keyboard expects.

The existing `reportID == 0` branch in `sendHIDFeatureReport` was incorrect: per Apple's IOKit docs, the `report` buffer passed to `IOHIDDeviceSetReport` must **never** include the report ID byte — it is always a separate parameter. That branch was sending an extra leading `0x00` to the device.

## Test plan

- [x] `go test ./internal/driver/ -run TestBuildApexPacket -v` — all 7 tests pass
- [x] `./build-darwin.sh` — compiles cleanly to a `Mach-O 64-bit executable arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)